### PR TITLE
Attachments support

### DIFF
--- a/attachment.go
+++ b/attachment.go
@@ -1,5 +1,11 @@
 package sofa
 
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+)
+
 // Attachment represents files or other data which is attached to documents in the
 // Database.
 type Attachment struct {
@@ -12,4 +18,68 @@ type Attachment struct {
 	RevPos        float64 `json:"revpos,omitempty"`
 	Stub          bool    `json:"stub,omitempty"`
 	Follows       bool    `json:"follows,omitempty"`
+}
+
+type attachmentPutResponse struct {
+	ID  string `json:"id"`
+	Rev string `json:"rev"`
+	OK  bool   `json:"ok"`
+}
+
+func (db *Database) GetAttachment(docid, name string) ([]byte, error) {
+	path := urlConcat(db.DocumentPath(docid), name)
+
+	resp, err := db.con.Get(path, NewURLOptions())
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+func (db *Database) PutAttachment(docid, name string, doc io.Reader) (string, error) {
+	path := urlConcat(db.DocumentPath(docid), name)
+
+	resp, err := db.con.Put(path, NewURLOptions(), doc)
+	if err != nil {
+		return "", err
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	ar := attachmentPutResponse{}
+	if err := json.Unmarshal(respBytes, &ar); err != nil {
+		return "", err
+	}
+
+	return ar.Rev, nil
+}
+
+func (db *Database) DeleteAttachment(docid, name, rev string) (string, error) {
+	path := urlConcat(db.DocumentPath(docid), name)
+
+	opts := NewURLOptions()
+	if err := opts.Set("rev", rev); err != nil {
+		return "", err
+	}
+
+	resp, err := db.con.Delete(path, opts)
+	if err != nil {
+		return "", err
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	ar := attachmentPutResponse{}
+	if err := json.Unmarshal(respBytes, &ar); err != nil {
+		return "", err
+	}
+
+	return ar.Rev, nil
 }

--- a/attachment_test.go
+++ b/attachment_test.go
@@ -1,0 +1,1 @@
+package sofa

--- a/attachment_test.go
+++ b/attachment_test.go
@@ -1,1 +1,69 @@
 package sofa
+
+import (
+	"strings"
+	"testing"
+)
+
+var (
+	AttachmentTestDB   = "attachment_test_db"
+	AttachmentFileName = "test.txt"
+	AttachmentContent  = "Hello Couchy McCouchface"
+)
+
+func TestAttachmentReal(t *testing.T) {
+	con := globalTestConnections.Version2(t, false)
+
+	// Create a new database
+	db, err := con.CreateDatabase(AttachmentTestDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc := &struct {
+		DocumentMetadata
+		Name string
+		Type string
+	}{
+		DocumentMetadata: DocumentMetadata{
+			ID: "fruit1",
+		},
+		Name: "apple",
+		Type: "fruit",
+	}
+
+	rev, err := db.Put(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attRev, err := db.PutAttachment(doc.DocumentMetadata.ID, AttachmentFileName, strings.NewReader(AttachmentContent), rev)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attBytes, err := db.GetAttachment(doc.DocumentMetadata.ID, AttachmentFileName, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attString := string(attBytes)
+
+	if attString != AttachmentContent {
+		t.Fatalf("attachment response did not contain expected content: %s", attString)
+	}
+
+	_, err = db.DeleteAttachment(doc.DocumentMetadata.ID, AttachmentFileName, attRev)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.GetAttachment(doc.DocumentMetadata.ID, AttachmentFileName, "")
+	if !ErrorStatus(err, 404) {
+		t.Fatalf("expected a 404 error getting attachment after deletion but got: %s", err)
+	}
+
+	if err := con.DeleteDatabase(AttachmentTestDB); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Add support for CouchDB attachments.

Saving attachments requires setting headers on the request which is likely to require some API changes.